### PR TITLE
Added list of top reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Get GitHub metrics for a repository.
 Supports obtaining metrics from:
 
 - Pull Requests
+- Issues
 
 ## To start
 

--- a/src/github/queries/PullRequestList.graphql
+++ b/src/github/queries/PullRequestList.graphql
@@ -23,6 +23,7 @@ query PullRequests($cursor: String, $owner: String!, $repo: String!) {
                 state
                 author {
                   login
+                  avatarUrl
                 }
               }
             }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -29,7 +29,7 @@ export interface PullRequestNode {
     nodes: {
       submittedAt: string;
       state: "APPROVED" | "COMMENTED" | "CHANGES_REQUESTED";
-      author: { login: string };
+      author: { login: string; avatarUrl: string };
     }[];
   };
 }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -27,7 +27,7 @@ export interface PullRequestNode {
   reviews: {
     totalCount: number;
     nodes: {
-      submittedAt: string;
+      submittedAt: string | null;
       state: "APPROVED" | "COMMENTED" | "CHANGES_REQUESTED";
       author: { login: string; avatarUrl: string };
     }[];

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -140,9 +140,9 @@ export class PullRequestAnalytics {
           : undefined,
         review: timeToFirstReview
           ? {
-              date: firstReview as string,
-              daysSinceCreation: timeToFirstReview,
-            }
+            date: firstReview as string,
+            daysSinceCreation: timeToFirstReview,
+          }
           : undefined,
         additions: pr.additions,
         deletions: pr.deletions,
@@ -175,19 +175,17 @@ export class PullRequestAnalytics {
         reviewsPerUser.set(review.author.login, authorReviews + 1);
       } else {
         // If the month is over, we check who reviewed the most that month
-        let topReviewer: [string, number] = ["", -1];
+        let topReviewer: { user: string, reviews: number, avatar: string } = { user: "", reviews: -1, avatar: "" };
         for (const [user, nrOfReviews] of reviewsPerUser) {
-          if (nrOfReviews > topReviewer[1]) {
-            topReviewer = [user, nrOfReviews];
+          if (nrOfReviews > topReviewer.reviews) {
+            topReviewer = { user, reviews: nrOfReviews, avatar: review.author.avatarUrl };
           }
         }
         // If there was at least one review, we add it to that month's top reviewer
-        if (topReviewer[1] > 0) {
-          const [user, nrOfReviews] = topReviewer;
+        if (topReviewer.reviews > 0) {
           monthsWithMatches.push({
             month: currentMonth.format("MMM YYYY"),
-            reviews: nrOfReviews,
-            user,
+            ...topReviewer
           });
         }
 

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -160,6 +160,7 @@ export class PullRequestAnalytics {
     return averages;
   }
 
+  /** Returns the reviewer who gave the biggest amount of reviews per month */
   getMonthlyReviewers(
     reviews: PullRequestNode["reviews"]["nodes"],
   ): PullRequestMetrics["reviewers"] {
@@ -238,6 +239,7 @@ export class PullRequestAnalytics {
     return monthsWithMatches;
   }
 
+  /** Returns the reviewer who gave the biggest amount of reviews */
   getTopReviewer(
     reviews: PullRequestNode["reviews"]["nodes"],
   ): PullRequestMetrics["topReviewer"] {

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -26,7 +26,7 @@ export class PullRequestAnalytics {
   constructor(
     private readonly api: RepositoryApi,
     private readonly logger: ActionLogger,
-    private readonly repo: { owner: string; repo: string },
+    repo: { owner: string; repo: string },
   ) {
     logger.debug(`Reporter has been configured for ${repo.owner}/${repo.repo}`);
   }
@@ -45,7 +45,7 @@ export class PullRequestAnalytics {
     const monthlyAverages = this.generateMonthlyAverages(prs);
 
     const reviewList = prList.flatMap((pr) => pr.reviews.nodes);
-    const reviewers = this.getTopReviewers(reviewList);
+    const reviewers = this.getMonthlyReviewers(reviewList);
 
     const topReviewer = this.getTopReviewer(reviewList);
 
@@ -160,7 +160,7 @@ export class PullRequestAnalytics {
     return averages;
   }
 
-  getTopReviewers(
+  getMonthlyReviewers(
     reviews: PullRequestNode["reviews"]["nodes"],
   ): PullRequestMetrics["reviewers"] {
     if (reviews.length === 0) {

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -7,7 +7,7 @@ import {
   calculateEventsPerMonth,
   extractMatchesFromDate,
 } from "../util";
-import { DurationWithInitialDate, MonthWithMatch, PullRequestMetrics } from "./types";
+import { DurationWithInitialDate, PullRequestMetrics } from "./types";
 
 interface PullRequestInfo {
   number: number;
@@ -44,7 +44,9 @@ export class PullRequestAnalytics {
     const monthlyMetrics = this.generateMonthlyMetrics(prs);
     const monthlyAverages = this.generateMonthlyAverages(prs);
 
-    const reviewers = this.getTopReviewers(prList.flatMap(pr => pr.reviews.nodes));
+    const reviewers = this.getTopReviewers(
+      prList.flatMap((pr) => pr.reviews.nodes),
+    );
 
     return { ...prMetric, monthlyMetrics, monthlyAverages, reviewers };
   }
@@ -138,9 +140,9 @@ export class PullRequestAnalytics {
           : undefined,
         review: timeToFirstReview
           ? {
-            date: firstReview as string,
-            daysSinceCreation: timeToFirstReview,
-          }
+              date: firstReview as string,
+              daysSinceCreation: timeToFirstReview,
+            }
           : undefined,
         additions: pr.additions,
         deletions: pr.deletions,
@@ -151,7 +153,9 @@ export class PullRequestAnalytics {
     return averages;
   }
 
-  getTopReviewers(reviews: PullRequestNode["reviews"]["nodes"]): PullRequestMetrics["reviewers"] {
+  getTopReviewers(
+    reviews: PullRequestNode["reviews"]["nodes"],
+  ): PullRequestMetrics["reviewers"] {
     if (reviews.length === 0) {
       return [];
     }
@@ -172,15 +176,19 @@ export class PullRequestAnalytics {
       } else {
         // If the month is over, we check who reviewed the most that month
         let topReviewer: [string, number] = ["", -1];
-        for (const [user, reviews] of reviewsPerUser) {
-          if (reviews > topReviewer[1]) {
-            topReviewer = [user, reviews];
+        for (const [user, nrOfReviews] of reviewsPerUser) {
+          if (nrOfReviews > topReviewer[1]) {
+            topReviewer = [user, nrOfReviews];
           }
         }
         // If there was at least one review, we add it to that month's top reviewer
         if (topReviewer[1] > 0) {
-          const [user, reviews] = topReviewer;
-          monthsWithMatches.push({ month: currentMonth.format("MMM YYYY"), reviews, user });
+          const [user, nrOfReviews] = topReviewer;
+          monthsWithMatches.push({
+            month: currentMonth.format("MMM YYYY"),
+            reviews: nrOfReviews,
+            user,
+          });
         }
 
         // We move the month to the next one

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -45,13 +45,17 @@ export class PullRequestAnalytics {
     const monthlyAverages = this.generateMonthlyAverages(prs);
 
     const reviewList = prList.flatMap((pr) => pr.reviews.nodes);
-    const reviewers = this.getTopReviewers(reviewList,
-    );
+    const reviewers = this.getTopReviewers(reviewList);
 
     const topReviewer = this.getTopReviewer(reviewList);
-    console.log("Top reviewer is",topReviewer)
 
-    return { ...prMetric, monthlyMetrics, monthlyAverages, reviewers ,topReviewer};
+    return {
+      ...prMetric,
+      monthlyMetrics,
+      monthlyAverages,
+      reviewers,
+      topReviewer,
+    };
   }
 
   generateMonthlyMetrics(
@@ -143,9 +147,9 @@ export class PullRequestAnalytics {
           : undefined,
         review: timeToFirstReview
           ? {
-            date: firstReview as string,
-            daysSinceCreation: timeToFirstReview,
-          }
+              date: firstReview as string,
+              daysSinceCreation: timeToFirstReview,
+            }
           : undefined,
         additions: pr.additions,
         deletions: pr.deletions,
@@ -242,8 +246,10 @@ export class PullRequestAnalytics {
     }
 
     const usersWithReviews: Reviewer[] = [];
-    for (const { author: { login, avatarUrl } } of reviews) {
-      const index = usersWithReviews.map(u => u.user).indexOf(login);
+    for (const {
+      author: { login, avatarUrl },
+    } of reviews) {
+      const index = usersWithReviews.map((u) => u.user).indexOf(login);
       if (index > -1) {
         usersWithReviews[index].reviews += 1;
       } else {
@@ -251,9 +257,7 @@ export class PullRequestAnalytics {
       }
     }
 
-    console.log("List of reviewers", usersWithReviews)
-
-    let topReviewer:PullRequestMetrics["topReviewer"] =  null;
+    let topReviewer: PullRequestMetrics["topReviewer"] = null;
     for (const candidate of usersWithReviews) {
       if (!topReviewer || candidate.reviews > topReviewer.reviews) {
         topReviewer = candidate;

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -255,9 +255,7 @@ export class PullRequestAnalytics {
 
     let topReviewer:PullRequestMetrics["topReviewer"] =  null;
     for (const candidate of usersWithReviews) {
-      if(!topReviewer){
-        topReviewer = candidate;
-      } else if (candidate.reviews > topReviewer.reviews){
+      if (!topReviewer || candidate.reviews > topReviewer.reviews) {
         topReviewer = candidate;
       }
     }

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -22,6 +22,7 @@ export interface PullRequestMetrics {
     /** Average lines changed per month */
     linesChanged: MonthWithMatch[];
   };
+  reviewers: {month:string, user:string, reviews:number}[];
 }
 
 export interface IssuesMetrics {

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -22,7 +22,7 @@ export interface PullRequestMetrics {
     /** Average lines changed per month */
     linesChanged: MonthWithMatch[];
   };
-  reviewers: { month: string; user: string; reviews: number }[];
+  reviewers: { month: string; user: string; reviews: number; avatar: string }[];
 }
 
 export interface IssuesMetrics {

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -1,3 +1,5 @@
+export type Reviewer = {user:string,avatar:string, reviews:number};
+
 export interface PullRequestMetrics {
   open: number;
   closed: number;
@@ -22,7 +24,8 @@ export interface PullRequestMetrics {
     /** Average lines changed per month */
     linesChanged: MonthWithMatch[];
   };
-  reviewers: { month: string; user: string; reviews: number; avatar: string }[];
+  reviewers: ({ month: string } & Reviewer)[];
+  topReviewer?:Reviewer|null;
 }
 
 export interface IssuesMetrics {

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -22,7 +22,7 @@ export interface PullRequestMetrics {
     /** Average lines changed per month */
     linesChanged: MonthWithMatch[];
   };
-  reviewers: {month:string, user:string, reviews:number}[];
+  reviewers: { month: string; user: string; reviews: number }[];
 }
 
 export interface IssuesMetrics {

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -1,4 +1,4 @@
-export type Reviewer = {user:string,avatar:string, reviews:number};
+export type Reviewer = { user: string; avatar: string; reviews: number };
 
 export interface PullRequestMetrics {
   open: number;
@@ -25,7 +25,7 @@ export interface PullRequestMetrics {
     linesChanged: MonthWithMatch[];
   };
   reviewers: ({ month: string } & Reviewer)[];
-  topReviewer?:Reviewer|null;
+  topReviewer?: Reviewer | null;
 }
 
 export interface IssuesMetrics {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -142,17 +142,27 @@ const generatePrSummary = (
 
   const reviewerOfTheMonth = prMetrics.reviewers.at(-1);
   if (reviewerOfTheMonth)
-    text = text.addHeading("Reviewer of the month", 4)
-      .addImage(reviewerOfTheMonth.avatar ?? "", `${reviewerOfTheMonth.user}'s avatar`)
-      .addRaw(`@${reviewerOfTheMonth.user} with ${reviewerOfTheMonth.reviews} reviews!`)
+    text = text
+      .addHeading("Reviewer of the month", 4)
+      .addImage(
+        reviewerOfTheMonth.avatar ?? "",
+        `${reviewerOfTheMonth.user}'s avatar`,
+      )
+      .addRaw(
+        `@${reviewerOfTheMonth.user} with ${reviewerOfTheMonth.reviews} reviews!`,
+      )
       .addEOL();
 
   if (prMetrics.topReviewer) {
     const { topReviewer } = prMetrics;
-    text = text.addHeading("Top reviewer", 3)
-      .addEOL().addImage(topReviewer.avatar, `${topReviewer.user}'s avatar`)
+    text = text
+      .addHeading("Top reviewer", 3)
       .addEOL()
-      .addRaw(`@${topReviewer.user} with a **total of ${topReviewer.reviews} reviews**!`);
+      .addImage(topReviewer.avatar, `${topReviewer.user}'s avatar`)
+      .addEOL()
+      .addRaw(
+        `@${topReviewer.user} with a **total of ${topReviewer.reviews} reviews**!`,
+      );
   }
   return text;
 };

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -116,6 +116,24 @@ const generatePrSummary = (
     )
     .addEOL();
 
+  // Top reviewers
+  const topReviewers = `\`\`\`mermaid
+  gantt
+    title Top reviewer per month
+    dateFormat X
+    axisFormat %s
+    ${prMetrics.reviewers
+    .map(
+      ({ month, user, reviews }) => `section ${month}\n    ${user} : 0, ${reviews}`,
+    )
+    .join("\n    ")}
+  \`\`\``;
+
+  text = text.addHeading("Top reviewers", 3)
+    .addEOL()
+    .addRaw(topReviewers)
+    .addEOL();
+
   return text;
 };
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -28,7 +28,7 @@ const generatePrSummary = (
   "Closed" : ${prMetrics.closed}
   \`\`\``;
 
-  text = summary.addHeading("PRs states", 3).addEOL().addRaw(prChart).addEOL();
+  text = summary.addHeading("Pull Requests", 1).addEOL().addRaw(prChart).addEOL();
 
   const totalAverageTimeToClose = calculateAverage(
     prMetrics.monthlyAverages.mergeTime.map(([_, average]) => average),
@@ -148,7 +148,7 @@ const generateIssueSummary = (
   \`\`\``;
 
   text = summary
-    .addHeading("Issues states", 3)
+    .addHeading("Issues", 1)
     .addEOL()
     .addRaw(prChart)
     .addEOL();

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -140,6 +140,12 @@ const generatePrSummary = (
     .addRaw(topReviewers)
     .addEOL();
 
+  const reviewerOfTheMonth = prMetrics.reviewers.at(-1);
+  if (reviewerOfTheMonth)
+    text = text.addHeading("Reviewer of the month", 4)
+      .addImage(reviewerOfTheMonth.avatar ?? "", `${reviewerOfTheMonth.user}'s avatar`)
+      .addRaw(`@${reviewerOfTheMonth.user} with ${reviewerOfTheMonth.reviews} reviews!`);
+
   return text;
 };
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -144,8 +144,16 @@ const generatePrSummary = (
   if (reviewerOfTheMonth)
     text = text.addHeading("Reviewer of the month", 4)
       .addImage(reviewerOfTheMonth.avatar ?? "", `${reviewerOfTheMonth.user}'s avatar`)
-      .addRaw(`@${reviewerOfTheMonth.user} with ${reviewerOfTheMonth.reviews} reviews!`);
+      .addRaw(`@${reviewerOfTheMonth.user} with ${reviewerOfTheMonth.reviews} reviews!`)
+      .addEOL();
 
+  if (prMetrics.topReviewer) {
+    const { topReviewer } = prMetrics;
+    text = text.addHeading("Top reviewer", 3)
+      .addEOL().addImage(topReviewer.avatar, `${topReviewer.user}'s avatar`)
+      .addEOL()
+      .addRaw(`@${topReviewer.user} with a **total of ${topReviewer.reviews} reviews**!`);
+  }
   return text;
 };
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -42,14 +42,14 @@ const generatePrSummary = (
 
   const averageReviews = `\`\`\`mermaid
     gantt
-        title Average Reviews time (days)
+        title Average PR time (days)
         dateFormat  X
         axisFormat %s
-        section Time to close
+        section To close
         ${totalAverageTimeToClose} : 0, ${totalAverageTimeToClose}
-        section Time to first review
+        section To first review
         ${totalAverageTimeToFirstReview} : 0, ${totalAverageTimeToFirstReview}
-        section Average reviews
+        section Reviews per PR
         ${totalAverageReviews} : 0, ${totalAverageReviews}
   \`\`\``;
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -28,7 +28,11 @@ const generatePrSummary = (
   "Closed" : ${prMetrics.closed}
   \`\`\``;
 
-  text = summary.addHeading("Pull Requests", 1).addEOL().addRaw(prChart).addEOL();
+  text = summary
+    .addHeading("Pull Requests", 1)
+    .addEOL()
+    .addRaw(prChart)
+    .addEOL();
 
   const totalAverageTimeToClose = calculateAverage(
     prMetrics.monthlyAverages.mergeTime.map(([_, average]) => average),
@@ -123,13 +127,15 @@ const generatePrSummary = (
     dateFormat X
     axisFormat %s
     ${prMetrics.reviewers
-    .map(
-      ({ month, user, reviews }) => `section ${month}\n    ${user} : 0, ${reviews}`,
-    )
-    .join("\n    ")}
+      .map(
+        ({ month, user, reviews }) =>
+          `section ${month}\n    ${user} : 0, ${reviews}`,
+      )
+      .join("\n    ")}
   \`\`\``;
 
-  text = text.addHeading("Top reviewers", 3)
+  text = text
+    .addHeading("Top reviewers", 3)
     .addEOL()
     .addRaw(topReviewers)
     .addEOL();
@@ -147,11 +153,7 @@ const generateIssueSummary = (
   "Closed" : ${issueMetrics.closed}
   \`\`\``;
 
-  text = summary
-    .addHeading("Issues", 1)
-    .addEOL()
-    .addRaw(prChart)
-    .addEOL();
+  text = summary.addHeading("Issues", 1).addEOL().addRaw(prChart).addEOL();
 
   const totalAverageTimeToClose = calculateAverage(
     issueMetrics.monthlyAverages.closeTime.map(([_, average]) => average),


### PR DESCRIPTION
Added list of top reviewers per month.

At the end of the report, a list showing who reviewed the most PRs each month is added.

Resolves paritytech/metrics#11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Added support for obtaining metrics from Issues in addition to Pull Requests.
	- Introduced a feature to calculate and display the top reviewers per month in the analytics section, enhancing the insights into review activities.
- **Enhancements**
	- Improved the analytics report's readability by renaming sections for better clarity and adding a new section for "Top reviewers."
- **Documentation**
	- Updated the `PullRequestMetrics` interface to include a new `reviewers` property, supporting the new analytics feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->